### PR TITLE
Update Celery Project Link

### DIFF
--- a/celery.md
+++ b/celery.md
@@ -1,7 +1,7 @@
 Celery
 ======
 
-[Celery](http://www.celeryproject.org/) is a distributed task queue used to run background tasks.
+[Celery](https://docs.celeryproject.org/) is a distributed task queue used to run background tasks.
 
 It is optional, but is required for the "background task" example to work.
 


### PR DESCRIPTION
Updated Celery link from http://www.celeryproject.org/ to https://docs.celeryproject.org/.