### PR TITLE
deploy docs reorg

### DIFF
--- a/deployment.rst
+++ b/deployment.rst
@@ -12,3 +12,4 @@ This section outlines everything you need to know to deploy your Pegasus app to 
    deployment/digital-ocean
    deployment/google-cloud
    deployment/production-checklist
+   deployment/troubleshooting

--- a/deployment/digital-ocean.md
+++ b/deployment/digital-ocean.md
@@ -36,6 +36,9 @@ That's it!
 In a few minutes your app should be online.
 You can [find and view it here](https://cloud.digitalocean.com/apps).
 
+**After deploying, review the [production checklist](/deployment/production-checklist.md) for a list
+of common next steps**
+
 ### Settings and Secrets
 
 App platform builds use the `settings_production.py` file.

--- a/deployment/digital-ocean.md
+++ b/deployment/digital-ocean.md
@@ -36,6 +36,14 @@ That's it!
 In a few minutes your app should be online.
 You can [find and view it here](https://cloud.digitalocean.com/apps).
 
+### Settings and Secrets
+
+App platform builds use the `settings_production.py` file.
+You can add settings here, and use environment variables to manage any secrets, following the pattern used
+throughout the file.
+
+Environment variables can be managed in the Digital Ocean dashboard [as described here](https://docs.digitalocean.com/products/app-platform/how-to/use-environment-variables/).
+
 ### Running One-Off Commands
 
 The easiest way to run once-off commands in your app is to click the "console" tab in app platform and just type in the command.
@@ -45,12 +53,6 @@ See the screenshot below for what it looks like:
 
 You may also need to run additional commands to get up and running, e.g. `./manage.py bootstrap_subscriptions`
 for initializing your Stripe plan data.
-
-### Settings and Secrets
-
-App platform builds use the `settings_production.py` file.
-You can add settings here, and use environment variables to manage any secrets, following the pattern used
-throughout the file.
 
 ### Celery Support
 

--- a/deployment/fly.md
+++ b/deployment/fly.md
@@ -91,18 +91,12 @@ You are now ready to deploy your app.
 $ fly deploy
 ```
 
+**After deploying, review the [production checklist](/deployment/production-checklist.md) for a list
+of common next steps**
+
 ### Running Database Migrations
 
 Database migrations are applied via during deploy. This is configured in the `fly.toml` file.
-
-You may also need to run additional commands to get up and running, e.g. `./manage.py bootstrap_subscriptions`
-for initializing your Stripe plan data. This can be done via a shell:
-
-```shell
-$ fly ssh console
-
-app $ ./code/manage.py [command]
-```
 
 ### Settings and Secrets
 
@@ -114,6 +108,16 @@ Secrets are managed in Fly.io via the web UI or on the command line using the CL
 
 ```shell
 $ fly secrets set MY_VAR=secret_value
+```
+
+### Running One-Off Commands
+
+You can one-off commands via a shell:
+
+```shell
+$ fly ssh console
+
+app $ ./code/manage.py [command]
 ```
 
 ### Celery Support

--- a/deployment/fly.md
+++ b/deployment/fly.md
@@ -101,7 +101,7 @@ for initializing your Stripe plan data. This can be done via a shell:
 ```shell
 $ fly ssh console
 
-app $ ./manage.py [command]
+app $ ./code/manage.py [command]
 ```
 
 ### Settings and Secrets

--- a/deployment/heroku.md
+++ b/deployment/heroku.md
@@ -67,6 +67,9 @@ git push heroku main
 
 You can also configure Heroku to automatically build from a branch of your git repository.
 
+**After deploying, review the [production checklist](/deployment/production-checklist.md) for a list
+of common next steps**
+
 ### Setting environment variables
 
 To set environment variables run:

--- a/deployment/heroku.md
+++ b/deployment/heroku.md
@@ -56,18 +56,6 @@ from the UI or by running:
 heroku addons:create heroku-redis
 ```
 
-
-### Setting allowed hosts
-
-In your `settings_production.py` file make sure to change the `ALLOWED_HOSTS` setting
-to include whatever app you're deploying.
-
-```
-ALLOWED_HOSTS = [
-    'myapp.herokuapp.com',
-]
-```
-
 ### Deploying
 
 Both builds can be deployed using Heroku's standard git integration.
@@ -79,6 +67,20 @@ git push heroku main
 
 You can also configure Heroku to automatically build from a branch of your git repository.
 
+### Setting environment variables
+
+To set environment variables run:
+
+```
+heroku config:set {variable_name}={ value }
+```
+
+e.g.
+
+```
+heroku config:set SECRET_KEY={some long randomly generated text}
+```
+
 
 ### Additional settings configuration
 
@@ -89,20 +91,16 @@ or include them as config vars like this:
 SECRET_KEY = env('SECRET_KEY')
 ```
 
-We recommend also setting `SECRET_KEY` in your Heroku config vars to avoid having it in version control.
+**It is strongly advised to put any secrets in your environment instead of directly in your settings file.**
 
-### Stripe support
+### Running one-off commands
 
-If you're using Stripe, you will need to set the `STRIPE_TEST_PUBLIC_KEY`, `STRIPE_TEST_SECRET_KEY`, 
-`STRIPE_LIVE_PUBLIC_KEY`, and `STRIPE_LIVE_SECRET_KEY` config vars (or whatever subset you are using).
-
-After setting up your Stripe variables, you can run:
+You can run once-off commands using the `heroku` CLI. E.g.
 
 ```
 heroku run python manage.py bootstrap_subscriptions
 ```
 
-to initialize your subscription data.
 
 ### Building the front end
 

--- a/deployment/overview.md
+++ b/deployment/overview.md
@@ -31,7 +31,7 @@ Heroku is the most common choice, and is the recommended option for staging site
 If you would like to deploy to a platform that's not listed here, please get in touch on Slack or by emailing 
 cory@saaspegasus.com and I'm happy to help!
 
-## Other options
+### Other options
 
 The maintainer of Pegasus hosts Pegasus apps on a virtual private server, using gunicorn and nginx.
 I'm happy to help support deployments like this, and am hoping to offer more automated tooling for them in the future.

--- a/deployment/production-checklist.md
+++ b/deployment/production-checklist.md
@@ -14,14 +14,44 @@ The default Pegasus configuration will contain some warnings, to help prevent mi
 can affect your site's availability. Not all warnings are serious issues and some may not be possible to address 
 (e.g. if part of your site must be available over HTTP instead of HTTPS).
 After running the `manage.py check --deploy` command you should read through the documentation for any issues you get
-and update the relevant settings where necessary. 
+and update the relevant settings where necessary.
 
-## Keep your secrets secret
+*Note: The "unable to guess serializer" warnings are safe to ignore, and will be fixed in a future version of Pegasus.*
 
-Your secrets---like production database passwords or Stripe API keys---should never be checked into source control.
-Instead, you should either put secrets in environment variables or in a .gitignored production settings file that
-lives only on the server.
-For supported deployment platforms, recommendations for managing secrets can be found in the platform-specific documentation.
+## Set your `ALLOWED_HOSTS`
+
+In your app's `settings_production.py` be sure to update the [`ALLOWED_HOSTS` setting](https://docs.djangoproject.com/en/4.1/ref/settings/#allowed-hosts)
+with the domain(s) you want the site to be available from, replacing the `'*'` that is there by default:
+
+```python
+ALLOWED_HOSTS = [
+    'example.com',  # use your app's domain here
+]
+```
+
+Failure to do this opens up your site to more HTTP host header attacks.
+
+## Update your Django Site
+
+In order for absolute URLs and JavaScript API clients to work, your Django site should match your application's domain.
+See the documentation on [absolute URLs](https://docs.saaspegasus.com/configuration.html#absolute-urls) to do this.
+
+## Set up email
+
+If you haven't already, you'll want to set up your site to [send email](https://docs.saaspegasus.com/configuration.html#sending-email)
+
+## Make sure your secrets are set
+
+Application secrets (e.g. API keys, passwords, etc.) are managed in environment variables.
+Ensure that you have configured the following variables (if you are using them):
+
+- All apps should set `SECRET_KEY` to a long, randomly-generated value.
+- If you're using Stripe, you should set the `STRIPE_TEST_PUBLIC_KEY`, `STRIPE_TEST_SECRET_KEY`, 
+`STRIPE_LIVE_PUBLIC_KEY`, and `STRIPE_LIVE_SECRET_KEY` config vars (or whatever subset you are using).
+- If you set up email, ensure whatever keys/secrets you need are set.
+- If you're using Mailchimp, set `MAILCHIMP_API_KEY` and `MAILCHIMP_LIST_ID`.
+
+Refer to your [chosen platform's documentation](/deployment.rst) for details on how to set environment variables in that platform.
 
 ## Optimize your front end
 
@@ -35,4 +65,9 @@ Then, as part of your CI/CD deployment process, you should build the bundle file
 This will ensure that the latest, optimized version of the front-end code is always deployed
 as part of your production environment.
 
-The platform-specific docs have some guidance on setting this up where possible.
+Some platThe platform-specific docs have some guidance on setting this up where possible.
+
+## Update other configuration options
+
+See [the configuration page](/configuration.md) for a larger list of options,
+including social login, sign up flow changes, analytics, logging, and so on.

--- a/deployment/production-checklist.md
+++ b/deployment/production-checklist.md
@@ -53,6 +53,18 @@ Ensure that you have configured the following variables (if you are using them):
 
 Refer to your [chosen platform's documentation](/deployment.rst) for details on how to set environment variables in that platform.
 
+## Sync Stripe data
+
+After setting up your Stripe variables per above, you'll want to run:
+
+```
+python manage.py bootstrap_subscriptions
+```
+
+to initialize your subscription data.
+
+See your [chosen platform's documentation](/deployment.rst) for how to run one-off commands.
+
 ## Optimize your front end
 
 The front-end files that ship with Pegasus are the developer-friendly versions.

--- a/deployment/render.md
+++ b/deployment/render.md
@@ -20,6 +20,9 @@ Once you've logged into Render you can create your app as follows:
 This will kick off the process to create your PostgreSQL database and Redis instances as well
 as deploy your web application.
 
+**After deploying, review the [production checklist](/deployment/production-checklist.md) for a list
+of common next steps**
+
 ### Start Script
 
 The `docker_startup.sh` file is run by Render to start your app.

--- a/deployment/render.md
+++ b/deployment/render.md
@@ -15,18 +15,22 @@ Once you've logged into Render you can create your app as follows:
 1. In the Render dashboard, create a new blueprint
 2. Connect your GitHub or Gitlab account and select your project's repository
 3. Configure the *Service Group Name* and select the branch you want to deploy from
-4. Review the configuration, add settings and click 'Approve'
+4. Review the configuration, add settings and click 'Apply'
 
 This will kick off the process to create your PostgreSQL database and Redis instances as well
-as deploy your application.
+as deploy your web application.
 
-### Running Database Migrations
+### Start Script
 
-Database migrations are applied via the Docker startup script or else the build script if you are
-not using Docker.
+The `docker_startup.sh` file is run by Render to start your app.
+This allows running "release" commands along with the web process, as [described here](https://community.render.com/t/release-command-for-db-migrations/247/2).
 
-You may also need to run additional commands to get up and running, e.g. `./manage.py bootstrap_subscriptions`
-for initializing your Stripe plan data. This can be done via a Render shell (paid plan required).
+Out of the box the `docker_startup.sh` file is where your database migrations will run,
+just before your app starts.
+
+If there are other commands, like `./manage.py bootstrap_subscriptions` that you want to run on every deploy you can add them here.
+
+You can also run one-off commands in the Render shell (paid plan required).
 
 ### Settings and Secrets
 

--- a/deployment/render.md
+++ b/deployment/render.md
@@ -30,13 +30,15 @@ just before your app starts.
 
 If there are other commands, like `./manage.py bootstrap_subscriptions` that you want to run on every deploy you can add them here.
 
-You can also run one-off commands in the Render shell (paid plan required).
-
 ### Settings and Secrets
 
 Render builds use the `settings_production.py` file.
 You can add settings here or in the base `settings.py` file, and use environment variables to manage any secrets,
 following the `SECRET_KEY` example.
+
+### Running One-Off Commands 
+
+You can run one-off commands in the Render shell (paid plan required) or [via SSH](https://render.com/docs/ssh).
 
 ### Celery Support
 

--- a/deployment/troubleshooting.md
+++ b/deployment/troubleshooting.md
@@ -1,0 +1,49 @@
+# Troubleshooting
+
+Below are some common issues related to deployment, and how to fix them.
+
+### Page displaying a 400 Bad Request error page
+
+**Problem:** 
+
+Your site deploys but you get a "400 Bad Request" when opening it in a browser.
+
+**Solution:**
+
+This is usually caused by a misconfigured `ALLOWED_HOSTS` setting.
+See [the section on `ALLOWED_HOSTS`](https://docs.saaspegasus.com/deployment/production-checklist.html#set-your-allowed-hosts) to fix.
+
+### JavaScript API clients not working
+
+**Problem**
+
+JavaScript API clients are failing to load data.
+This is likely the problem if the employee React demo or the teams list UI don't work properly.
+
+**Solution:**
+
+This is usually caused by a misconfigured Django site.
+See the documentation on [absolute URLs](https://docs.saaspegasus.com/configuration.html#absolute-urls) to fix.
+
+### Invitation / account emails have the wrong links
+
+**Problem**
+
+When you try to confirm an email address or accept a team invitation you are sent to the wrong site
+(e.g. localhost).
+
+**Solution:**
+
+This is usually caused by a misconfigured Django site.
+See the documentation on [absolute URLs](https://docs.saaspegasus.com/configuration.html#absolute-urls) to fix.
+
+### Stripe callbacks are going to the wrong place
+
+**Problem**
+
+After completing a payment in Stripe Checkout, you are redirected to the wrong place (e.g. localhost).
+
+**Solution:**
+
+This is usually caused by a misconfigured Django site.
+See the documentation on [absolute URLs](https://docs.saaspegasus.com/configuration.html#absolute-urls) to fix.


### PR DESCRIPTION
I noticed there was a fair amount of duplication across platform docs, so attempted to reconcile them. (this is a PR into #21)

1. Expanded the production checklist
2. Focused platform-specific docs on "settings/secrets" and "running once-off commands" sections
3. Added troubleshooting section
4. Other small tweaks